### PR TITLE
Removed custom event from update_selected_select

### DIFF
--- a/jquery.fancy_forms.js
+++ b/jquery.fancy_forms.js
@@ -84,7 +84,6 @@ Version: 0.1
 			options.selected  =  options.$wrap.find('option:selected');
 			options.$visible.html(options.selected.html());
 
-			$el.trigger(event_change, options);
 		},
 
 		/* Shared


### PR DESCRIPTION
$el.trigger(event_change, options) in update_selected_select is causing an infinite loop and is not needed. 
